### PR TITLE
Sync teams across multiple GitHub installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,15 @@ $ heroku addons:open scheduler
 Schedule the `rake sync` task:
 
 ![](https://camo.githubusercontent.com/845a96db7011c1180ca149d20a89c3c9e245dd25/68747470733a2f2f662e636c6f75642e6769746875622e636f6d2f6173736574732f3133372f3332363137312f37633361346534382d396232342d313165322d383331332d6663363539323331656663312e706e67)
+
+## Sync Across GitHub Installations
+
+If you are a GitHub Enterprise client, you may want to sync your teams from and to your GitHub
+Enterprise installation. You can do that easily by using a few different configuration options.
+
+| Environment Variable | Description |
+| -------------------- | ----------- |
+| SOURCE_GITHUB_ACCESS_TOKEN | A GitHub access token (with admin:org scope) from the source installation |
+| SOURCE_API_ENDPOINT | Set this if you're looking to sync *from* an Enterprise installation (otherwise, do not set this) |
+| TARGET_GITHUB_ACCESS_TOKEN | A GitHub access token (with admin:org scope) from the target installation |
+| TARGET_API_ENDPOINT | Set this if you're looking to sync *to* an Enterprise installation (otherwise, do not set this) |

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,9 @@
 require 'octokit'
 
 Octokit.auto_paginate = true
-client = Octokit::Client.new :access_token => ENV['GITHUB_ACCESS_TOKEN']
+source_client      = Octokit::Client.new :access_token => ENV['SOURCE_GITHUB_ACCESS_TOKEN']
+destination_client = Octokit::Client.new :access_token => ENV['DESTINATION_GITHUB_ACCESS_TOKEN'],
+                                         :api_endpoint => "https://ghe.io/api/v3"
 
 # Array[members_to_add Array, members_to_remove Array, unchanged Array]
 def reconcile_members(source, target)
@@ -14,35 +16,56 @@ end
 
 namespace :team do
   task :sync do
-    source_org, source_team = ENV['SOURCE'].split('/')
-    target_org, target_team = ENV['TARGET'].split('/')
+    puts "sync"
+    source_org, source_team_name = ENV['SOURCE'].split('/')
+    target_org, target_team_name = ENV['TARGET'].split('/')
 
-    source_org_teams = client.organization_teams(source_org)
+    puts "source_org: #{source_org} team:#{source_team_name}"
+    puts "target_org: #{target_org} team:#{target_team_name}"
+
+    source_org_teams = source_client.organization_teams(source_org)
+
     target_org_teams =
       if source_org == target_org
         source_org_teams
       else
-        client.organization_teams(target_org)
+        destination_client.organization_teams(target_org)
       end
 
-    source_id = source_org_teams.detect{ |t| t.slug == source_team }[:id]
-    target_id = source_org_teams.detect{ |t| t.slug == target_team }[:id]
+    source_id = source_org_teams.detect{ |t| t.slug == source_team_name }[:id]
+    target_team = target_org_teams.detect{ |t| t.slug == target_team_name }
+    target_id = target_team && target_team.id
+
+    puts "target_id: #{target_id}"
+    if target_id.nil?
+      puts "Need to create team '#{target_team_name}'"
+      team = destination_client.create_team(target_org, {:name => target_team_name})
+      puts team.inspect
+      target_id = team.id
+    end
 
     # https://developer.github.com/v3/orgs/teams/#list-team-members
-    source_members = Set.new client.team_members(source_id).map(&:login)
-    target_members = Set.new client.team_members(target_id).map(&:login)
+    source_members = Set.new source_client.team_members(source_id).map(&:login)
+    target_members = Set.new destination_client.team_members(target_id).map(&:login)
+
+    puts "source_members: #{source_members.inspect}"
+    puts "target_members: #{target_members.inspect}"
 
     to_add, to_remove, rest = reconcile_members(source_members, target_members)
 
     to_add.each do |login|
       # https://developer.github.com/v3/orgs/teams/#add-team-member
-      client.add_team_member(target_id, login)
+      destination_client.add_team_member(target_id, login)
     end
 
     to_remove.each do |login|
       # https://developer.github.com/v3/orgs/teams/#remove-team-member
-      client.remove_team_member(target_id, login)
+      destination_client.remove_team_member(target_id, login)
     end
+
+    puts "To Add: #{to_add.inspect}"
+    puts "To Remove: #{to_remove.inspect}"
+    puts "Rest: #{rest.inspect}"
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -29,12 +29,12 @@ namespace :team do
       end
 
     source_id = source_org_teams.detect{ |t| t.slug == source_team_name }[:id]
-    target_team = target_org_teams.detect{ |t| t.slug == target_team_name }
-    target_id = target_team && target_team.id
 
-    if target_id.nil?
-      team = destination_client.create_team(target_org, {:name => target_team_name})
-      target_id = team.id
+    target_team = target_org_teams.detect{ |t| t.slug == target_team_name }
+    target_id = if target_team
+      target_team.id
+    else
+      destination_client.create_team(target_org, {:name => target_team_name}).id
     end
 
     # https://developer.github.com/v3/orgs/teams/#list-team-members

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,13 @@
 require 'octokit'
 
 Octokit.auto_paginate = true
-source_client      = Octokit::Client.new :access_token => ENV['SOURCE_GITHUB_ACCESS_TOKEN']
-destination_client = Octokit::Client.new :access_token => ENV['DESTINATION_GITHUB_ACCESS_TOKEN'],
-                                         :api_endpoint => ENV['DESTINATION_API_ENDPOINT']
+source_client      = Octokit::Client.new :access_token => ENV['GITHUB_ACCESS_TOKEN'] || ENV['SOURCE_GITHUB_ACCESS_TOKEN']
+destination_client = if ENV['DESTINATION_API_ENDPOINT']
+  destination_client = Octokit::Client.new :access_token => ENV['DESTINATION_GITHUB_ACCESS_TOKEN'],
+                                           :api_endpoint => ENV['DESTINATION_API_ENDPOINT']
+else
+  source_client
+end
 
 # Array[members_to_add Array, members_to_remove Array, unchanged Array]
 def reconcile_members(source, target)

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,8 @@ require 'octokit'
 
 Octokit.auto_paginate = true
 source_client      = Octokit::Client.new :access_token => ENV['GITHUB_ACCESS_TOKEN'] || ENV['SOURCE_GITHUB_ACCESS_TOKEN']
-destination_client = if ENV['DESTINATION_API_ENDPOINT']
-  destination_client = Octokit::Client.new :access_token => ENV['DESTINATION_GITHUB_ACCESS_TOKEN'],
+target_client = if ENV['DESTINATION_API_ENDPOINT']
+  Octokit::Client.new :access_token => ENV['DESTINATION_GITHUB_ACCESS_TOKEN'],
                                            :api_endpoint => ENV['DESTINATION_API_ENDPOINT']
 else
   source_client
@@ -29,7 +29,7 @@ namespace :team do
       if source_org == target_org
         source_org_teams
       else
-        destination_client.organization_teams(target_org)
+        target_client.organization_teams(target_org)
       end
 
     source_id = source_org_teams.detect{ |t| t.slug == source_team_name }[:id]
@@ -38,23 +38,23 @@ namespace :team do
     target_id = if target_team
       target_team.id
     else
-      destination_client.create_team(target_org, {:name => target_team_name}).id
+      target_client.create_team(target_org, {:name => target_team_name}).id
     end
 
     # https://developer.github.com/v3/orgs/teams/#list-team-members
     source_members = Set.new source_client.team_members(source_id).map(&:login)
-    target_members = Set.new destination_client.team_members(target_id).map(&:login)
+    target_members = Set.new target_client.team_members(target_id).map(&:login)
 
     to_add, to_remove, rest = reconcile_members(source_members, target_members)
 
     to_add.each do |login|
       # https://developer.github.com/v3/orgs/teams/#add-team-member
-      destination_client.add_team_member(target_id, login)
+      target_client.add_team_member(target_id, login)
     end
 
     to_remove.each do |login|
       # https://developer.github.com/v3/orgs/teams/#remove-team-member
-      destination_client.remove_team_member(target_id, login)
+      target_client.remove_team_member(target_id, login)
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -7,9 +7,9 @@ source_client = if ENV['SOURCE_API_ENDPOINT']
 else
   Octokit::Client.new :access_token => ENV['GITHUB_ACCESS_TOKEN']
 end
-target_client = if ENV['DESTINATION_API_ENDPOINT']
-  Octokit::Client.new :access_token => ENV['DESTINATION_GITHUB_ACCESS_TOKEN'],
-                      :api_endpoint => ENV['DESTINATION_API_ENDPOINT']
+target_client = if ENV['TARGET_API_ENDPOINT']
+  Octokit::Client.new :access_token => ENV['TARGET_GITHUB_ACCESS_TOKEN'],
+                      :api_endpoint => ENV['TARGET_API_ENDPOINT']
 else
   source_client
 end

--- a/Rakefile
+++ b/Rakefile
@@ -16,12 +16,8 @@ end
 
 namespace :team do
   task :sync do
-    puts "sync"
     source_org, source_team_name = ENV['SOURCE'].split('/')
     target_org, target_team_name = ENV['TARGET'].split('/')
-
-    puts "source_org: #{source_org} team:#{source_team_name}"
-    puts "target_org: #{target_org} team:#{target_team_name}"
 
     source_org_teams = source_client.organization_teams(source_org)
 
@@ -36,20 +32,14 @@ namespace :team do
     target_team = target_org_teams.detect{ |t| t.slug == target_team_name }
     target_id = target_team && target_team.id
 
-    puts "target_id: #{target_id}"
     if target_id.nil?
-      puts "Need to create team '#{target_team_name}'"
       team = destination_client.create_team(target_org, {:name => target_team_name})
-      puts team.inspect
       target_id = team.id
     end
 
     # https://developer.github.com/v3/orgs/teams/#list-team-members
     source_members = Set.new source_client.team_members(source_id).map(&:login)
     target_members = Set.new destination_client.team_members(target_id).map(&:login)
-
-    puts "source_members: #{source_members.inspect}"
-    puts "target_members: #{target_members.inspect}"
 
     to_add, to_remove, rest = reconcile_members(source_members, target_members)
 
@@ -62,10 +52,6 @@ namespace :team do
       # https://developer.github.com/v3/orgs/teams/#remove-team-member
       destination_client.remove_team_member(target_id, login)
     end
-
-    puts "To Add: #{to_add.inspect}"
-    puts "To Remove: #{to_remove.inspect}"
-    puts "Rest: #{rest.inspect}"
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,15 @@
 require 'octokit'
 
 Octokit.auto_paginate = true
-source_client      = Octokit::Client.new :access_token => ENV['GITHUB_ACCESS_TOKEN'] || ENV['SOURCE_GITHUB_ACCESS_TOKEN']
+source_client = if ENV['SOURCE_API_ENDPOINT']
+  Octokit::Client.new :access_token => ENV['SOURCE_GITHUB_ACCESS_TOKEN'],
+                      :api_endpoint => ENV['SOURCE_API_ENDPOINT']
+else
+  Octokit::Client.new :access_token => ENV['GITHUB_ACCESS_TOKEN']
+end
 target_client = if ENV['DESTINATION_API_ENDPOINT']
   Octokit::Client.new :access_token => ENV['DESTINATION_GITHUB_ACCESS_TOKEN'],
-                                           :api_endpoint => ENV['DESTINATION_API_ENDPOINT']
+                      :api_endpoint => ENV['DESTINATION_API_ENDPOINT']
 else
   source_client
 end

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'octokit'
 Octokit.auto_paginate = true
 source_client      = Octokit::Client.new :access_token => ENV['SOURCE_GITHUB_ACCESS_TOKEN']
 destination_client = Octokit::Client.new :access_token => ENV['DESTINATION_GITHUB_ACCESS_TOKEN'],
-                                         :api_endpoint => "https://ghe.io/api/v3"
+                                         :api_endpoint => ENV['DESTINATION_API_ENDPOINT']
 
 # Array[members_to_add Array, members_to_remove Array, unchanged Array]
 def reconcile_members(source, target)


### PR DESCRIPTION
This is a spike to sync teams across GitHub installations. The goal here is to allow a team on GitHub.com to sync to or from a GitHub Enterprise installation.

Things left to do:
- [x] Allow syncing to or from a GitHub Enterprise installation (currently, you can only sync _to_ a GitHub Enterprise installation)
- [x] Change `destination` to the existing `target` wording

@mtodd I'm killing off my fork of this repo and working here now. :grinning:
